### PR TITLE
Add 'Nothing Follows' row and income details to IAR report

### DIFF
--- a/app/src/components/previewDocumentFiles/InspectionAcceptanceReportForIAR.tsx
+++ b/app/src/components/previewDocumentFiles/InspectionAcceptanceReportForIAR.tsx
@@ -1,17 +1,5 @@
 import React, { useRef, useEffect } from "react";
-import {
-  Box,
-  Typography,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-  styled,
-  Button,
-} from "@mui/material";
+import { Box, Typography, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, styled, Button } from "@mui/material";
 import { InspectionAcceptanceReportPropsForIAR } from "../../types/previewPrintDocument/types";
 import { Divider } from "@mui/material";
 import { capitalizeFirstLetter } from "../../utils/generalUtils";
@@ -70,28 +58,20 @@ export default function InspectionAcceptanceReportForIAR({
   onClose,
   poOverrides, // NEW: optional overrides { invoice, dateOfPayment }
 }: any) {
-
   const componentRef = useRef(null);
   // Use signatories provided by parent (Inventory page)
   // --- ADDED: normalize reportData to an array and compute totals ---
 
-  console.log({signatories});
+  console.log({ signatories });
 
-  const items: any[] = Array.isArray(reportData)
-    ? reportData
-    : reportData
-    ? [reportData]
-    : [];
+  const items: any[] = Array.isArray(reportData) ? reportData : reportData ? [reportData] : [];
 
   // purchase order info (use first item if array)
   const purchaseOrder = items[0]?.PurchaseOrder || reportData?.PurchaseOrder || null;
   const invoiceText = (poOverrides?.invoice ?? purchaseOrder?.invoice ?? "") as string;
   const dateOfPaymentText = (poOverrides?.dateOfPayment ?? purchaseOrder?.dateOfPayment ?? "") as string;
 
-  const totalAmount = items.reduce(
-    (sum, it) => sum + Number(it?.amount ?? 0),
-    0
-  );
+  const totalAmount = items.reduce((sum, it) => sum + Number(it?.amount ?? 0), 0);
   // --- end added ---
 
   // Create and inject print styles dynamically
@@ -147,19 +127,13 @@ export default function InspectionAcceptanceReportForIAR({
 
   return (
     <>
-      <PrintControls
-        sx={{ mb: 2, display: "flex", justifyContent: "space-between" }}
-      >
+      <PrintControls sx={{ mb: 2, display: "flex", justifyContent: "space-between" }}>
         {/* <Button onClick={onClose} variant="outlined">Back</Button> */}
         {/* <Button onClick={handlePrint} variant="contained">Print Report</Button>  */}
       </PrintControls>
 
       <Box id="printable-report" ref={componentRef}>
-        <TableContainer
-          component={Paper}
-          elevation={0}
-          sx={{ border: "1px solid black" }}
-        >
+        <TableContainer component={Paper} elevation={0} sx={{ border: "1px solid black" }}>
           <Table sx={{ width: "100%", borderCollapse: "collapse" }}>
             <TableHead>
               <TableRow sx={{ visibility: "collapse", height: 0 }}>
@@ -212,22 +186,13 @@ export default function InspectionAcceptanceReportForIAR({
                           placeItems: "center",
                         }}
                       >
-                        <Typography
-                          variant="h6"
-                          sx={{ fontSize: "14px", fontWeight: "normal" }}
-                        >
+                        <Typography variant="h6" sx={{ fontSize: "14px", fontWeight: "normal" }}>
                           REPUBLIC OF THE PHILIPPINES
                         </Typography>
-                        <Typography
-                          variant="h5"
-                          sx={{ fontSize: "16px", fontWeight: 600 }}
-                        >
+                        <Typography variant="h5" sx={{ fontSize: "16px", fontWeight: 600 }}>
                           CARLOS HILADO MEMORIAL STATE UNIVERSITY
                         </Typography>
-                        <Typography
-                          variant="h6"
-                          sx={{ fontSize: "14px", fontWeight: "normal" }}
-                        >
+                        <Typography variant="h6" sx={{ fontSize: "14px", fontWeight: "normal" }}>
                           INSPECTION & ACCEPTANCE REPORT
                         </Typography>
                       </Box>
@@ -281,40 +246,22 @@ export default function InspectionAcceptanceReportForIAR({
               </TableRow>
 
               <TableRow>
-                <StyledTableCellHeader colSpan={2}>
-                  Supplier:
-                </StyledTableCellHeader>
-                <StyledTableCellHeader colSpan={6}>
-                  {purchaseOrder?.supplier || ""}
-                </StyledTableCellHeader>
+                <StyledTableCellHeader colSpan={2}>Supplier:</StyledTableCellHeader>
+                <StyledTableCellHeader colSpan={6}>{purchaseOrder?.supplier || ""}</StyledTableCellHeader>
               </TableRow>
 
               <TableRow>
-                <StyledTableCellHeader colSpan={2}>
-                  PO # & Date:
-                </StyledTableCellHeader>
-                <StyledTableCellHeader>
-                  {purchaseOrder?.poNumber || ""}
-                </StyledTableCellHeader>
-                <StyledTableCellHeader>
-                  {purchaseOrder?.dateOfDelivery || ""}
-                </StyledTableCellHeader>
+                <StyledTableCellHeader colSpan={2}>PO # & Date:</StyledTableCellHeader>
+                <StyledTableCellHeader>{purchaseOrder?.poNumber || ""}</StyledTableCellHeader>
+                <StyledTableCellHeader>{purchaseOrder?.dateOfDelivery || ""}</StyledTableCellHeader>
                 <StyledTableCellHeader>Invoice# & Date:</StyledTableCellHeader>
-                <StyledTableCellHeader colSpan={2}>
-                  {invoiceText}
-                </StyledTableCellHeader>
-                <StyledTableCellHeader>
-                  {dateOfPaymentText}
-                </StyledTableCellHeader>
+                <StyledTableCellHeader colSpan={2}>{invoiceText}</StyledTableCellHeader>
+                <StyledTableCellHeader>{dateOfPaymentText}</StyledTableCellHeader>
               </TableRow>
 
               <TableRow>
-                <StyledTableCellHeader colSpan={3}>
-                  Requisitioning Office/Department:
-                </StyledTableCellHeader>
-                <StyledTableCellHeader colSpan={5}>
-                  {purchaseOrder?.placeOfDelivery || ""}
-                </StyledTableCellHeader>
+                <StyledTableCellHeader colSpan={3}>Requisitioning Office/Department:</StyledTableCellHeader>
+                <StyledTableCellHeader colSpan={5}>{purchaseOrder?.placeOfDelivery || ""}</StyledTableCellHeader>
               </TableRow>
 
               <TableRow sx={{ "& th": { padding: "1px 0px" } }}>
@@ -331,49 +278,60 @@ export default function InspectionAcceptanceReportForIAR({
 
             <TableBody>
               {items.length ? (
-                items.map((rd, idx) => (
-                  <StyledTableRow key={rd.id ?? idx}>
-                    <StyledTableCell>{idx + 1}</StyledTableCell>
-                    <StyledTableCell>{rd.unit || ""}</StyledTableCell>
-                    <StyledTableCell colSpan={3} sx={{ textAlign: "left", verticalAlign: "top", padding: "6px" }}>
-                      <Box>
-                        <Typography sx={{ fontWeight: 500, mb: 0.5 }}>
-                          {rd.description || rd.PurchaseOrderItem?.description || ""}
-                        </Typography>
+                <>
+                  {items.map((rd, idx) => (
+                    <StyledTableRow key={rd.id ?? idx}>
+                      <StyledTableCell>{idx + 1}</StyledTableCell>
+                      <StyledTableCell>{rd.unit || ""}</StyledTableCell>
+                      <StyledTableCell colSpan={3} sx={{ textAlign: "left", verticalAlign: "top", padding: "6px" }}>
+                        <Box>
+                          <Typography sx={{ fontWeight: 500, mb: 0.5 }}>{rd.description || rd.PurchaseOrderItem?.description || ""}</Typography>
 
-                        {rd.PurchaseOrderItem?.specification ? (
-                          <Typography
-                            sx={{
-                              whiteSpace: "pre-line",
-                              fontSize: "12px",
-                              color: "text.secondary",
-                              mb: 0.5,
-                              textAlign: "left",
-                            }}
-                          >
-                            {rd.PurchaseOrderItem.specification}
-                          </Typography>
-                        ) : null}
+                          {rd.PurchaseOrderItem?.specification ? (
+                            <Typography
+                              sx={{
+                                whiteSpace: "pre-line",
+                                fontSize: "12px",
+                                color: "text.secondary",
+                                mb: 0.5,
+                                textAlign: "left",
+                              }}
+                            >
+                              {rd.PurchaseOrderItem.specification}
+                            </Typography>
+                          ) : null}
 
-                        {rd.PurchaseOrderItem?.generalDescription ? (
-                          <Typography
-                            sx={{
-                              whiteSpace: "pre-line",
-                              fontSize: "12px",
-                              color: "text.secondary",
-                              textAlign: "left",
-                            }}
-                          >
-                            {rd.PurchaseOrderItem.generalDescription}
-                          </Typography>
-                        ) : null}
-                      </Box>
+                          {rd.PurchaseOrderItem?.generalDescription ? (
+                            <Typography
+                              sx={{
+                                whiteSpace: "pre-line",
+                                fontSize: "12px",
+                                color: "text.secondary",
+                                textAlign: "left",
+                              }}
+                            >
+                              {rd.PurchaseOrderItem.generalDescription}
+                            </Typography>
+                          ) : null}
+                        </Box>
+                      </StyledTableCell>
+                      <StyledTableCell>{rd.actualQuantityReceived ?? ""}</StyledTableCell>
+                      <StyledTableCell>{rd.unitCost ?? ""}</StyledTableCell>
+                      <StyledTableCell>{rd.amount ?? ""}</StyledTableCell>
+                    </StyledTableRow>
+                  ))}
+
+                  <StyledTableRow>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell colSpan={3} sx={{ textAlign: "center", padding: 0.5 }}>
+                      <Typography sx={{ fontSize: "12px", color: "text.secondary" }}>*****Nothing Follows*****</Typography>
                     </StyledTableCell>
-                    <StyledTableCell>{rd.actualQuantityReceived ?? ""}</StyledTableCell>
-                    <StyledTableCell>{rd.unitCost ?? ""}</StyledTableCell>
-                    <StyledTableCell>{rd.amount ?? ""}</StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
                   </StyledTableRow>
-                ))
+                </>
               ) : (
                 <StyledTableRow>
                   <StyledTableCell></StyledTableCell>
@@ -388,11 +346,19 @@ export default function InspectionAcceptanceReportForIAR({
               <StyledTableRow>
                 <StyledTableCell></StyledTableCell>
                 <StyledTableCell></StyledTableCell>
-                <StyledTableCell colSpan={4}></StyledTableCell>
-                <StyledTableCell>Total</StyledTableCell>
-                <StyledTableCell>
-                  {totalAmount || ""}
+                <StyledTableCell colSpan={4}>
+                  <Typography fontSize={12}>
+                    Income: <span>(Value)</span>
+                  </Typography>
+                  <Typography fontSize={12}>
+                    MDS: <span>(Value)</span>
+                  </Typography>
+                  <Typography fontSize={12}>
+                    Details: <span>(Value)</span>
+                  </Typography>
                 </StyledTableCell>
+                <StyledTableCell>Total</StyledTableCell>
+                <StyledTableCell>{totalAmount || ""}</StyledTableCell>
               </StyledTableRow>
 
               <StyledTableRow>
@@ -433,10 +399,7 @@ export default function InspectionAcceptanceReportForIAR({
                             border: "1px dotted black",
                           }}
                         ></Box>
-                        <Typography>
-                          Inspected, verified and found in order as to quantity
-                          and specification
-                        </Typography>
+                        <Typography>Inspected, verified and found in order as to quantity and specification</Typography>
                       </Box>
                     </Box>
                     <Box
@@ -488,9 +451,7 @@ export default function InspectionAcceptanceReportForIAR({
                             width: "40px",
                             aspectRatio: "3/2",
                             border: "1px dotted black",
-                            backgroundColor: items.every(i => i.iarStatus === "complete")
-                              ? "#ccc"
-                              : "transparent",
+                            backgroundColor: items.every((i) => i.iarStatus === "complete") ? "#ccc" : "transparent",
                             display: "flex",
                             alignItems: "center",
                             justifyContent: "center",
@@ -498,7 +459,7 @@ export default function InspectionAcceptanceReportForIAR({
                             fontWeight: "bold",
                           }}
                         >
-                          {items.every(i => i.iarStatus === "complete") ? "✓" : ""}
+                          {items.every((i) => i.iarStatus === "complete") ? "✓" : ""}
                         </Box>
                         <Typography sx={{ width: "65px" }}>Complete</Typography>
                       </Box>
@@ -514,9 +475,7 @@ export default function InspectionAcceptanceReportForIAR({
                             width: "40px",
                             aspectRatio: "3/2",
                             border: "1px dotted black",
-                            backgroundColor: items.some(i => i.iarStatus === "partial")
-                              ? "#ccc"
-                              : "transparent",
+                            backgroundColor: items.some((i) => i.iarStatus === "partial") ? "#ccc" : "transparent",
                             display: "flex",
                             alignItems: "center",
                             justifyContent: "center",
@@ -524,7 +483,7 @@ export default function InspectionAcceptanceReportForIAR({
                             fontWeight: "bold",
                           }}
                         >
-                          {items.some(i => i.iarStatus === "partial") ? "✓" : ""}
+                          {items.some((i) => i.iarStatus === "partial") ? "✓" : ""}
                         </Box>
                         <Typography sx={{ width: "65px" }}>Partial</Typography>
                       </Box>

--- a/app/src/components/printDocumentFiles/inspectionAcceptanceRerportForIAR.tsx
+++ b/app/src/components/printDocumentFiles/inspectionAcceptanceRerportForIAR.tsx
@@ -6,33 +6,26 @@ export const getInspectionReportTemplateForIAR = (
   poOverrides?: { invoice?: string; dateOfPayment?: string } // NEW
 ) => {
   // normalize input to array
-  const items: any[] = Array.isArray(reportData)
-    ? reportData
-    : reportData
-    ? [reportData]
-    : [];
+  const items: any[] = Array.isArray(reportData) ? reportData : reportData ? [reportData] : [];
 
   const purchaseOrder = items[0]?.PurchaseOrder || {};
   const invoiceText = escapeHtml(String(poOverrides?.invoice ?? purchaseOrder?.invoice ?? ""));
   const dateOfPaymentText = escapeHtml(String(poOverrides?.dateOfPayment ?? purchaseOrder?.dateOfPayment ?? ""));
 
   // helpers already imported: escapeHtml, nl2br
-  const rowsHtml = items
-    .map((it: any, idx: number) => {
-      const desc = escapeHtml(it.description || it.PurchaseOrderItem?.description || "");
-      const specHtml = it.PurchaseOrderItem?.specification
-        ? nl2br(it.PurchaseOrderItem.specification)
-        : "";
-      const genDescHtml = it.PurchaseOrderItem?.generalDescription
-        ? nl2br(it.PurchaseOrderItem.generalDescription)
-        : "";
+  const rowsHtml =
+    items
+      .map((it: any, idx: number) => {
+        const desc = escapeHtml(it.description || it.PurchaseOrderItem?.description || "");
+        const specHtml = it.PurchaseOrderItem?.specification ? nl2br(it.PurchaseOrderItem.specification) : "";
+        const genDescHtml = it.PurchaseOrderItem?.generalDescription ? nl2br(it.PurchaseOrderItem.generalDescription) : "";
 
-      const qty = escapeHtml(String(it.actualQuantityReceived ?? it.quantity ?? ""));
-      const unit = escapeHtml(it.unit ?? "");
-      const unitCost = escapeHtml(String(it.unitCost ?? it.PurchaseOrderItem?.unitCost ?? ""));
-      const amount = escapeHtml(String(it.amount ?? it.PurchaseOrderItem?.amount ?? ""));
+        const qty = escapeHtml(String(it.actualQuantityReceived ?? it.quantity ?? ""));
+        const unit = escapeHtml(it.unit ?? "");
+        const unitCost = escapeHtml(String(it.unitCost ?? it.PurchaseOrderItem?.unitCost ?? ""));
+        const amount = escapeHtml(String(it.amount ?? it.PurchaseOrderItem?.amount ?? ""));
 
-      return `
+        return `
         <tr>
           <td style="padding:4px">${idx + 1}</td>
           <td style="padding:4px">${unit}</td>
@@ -46,20 +39,30 @@ export const getInspectionReportTemplateForIAR = (
           <td style="padding:4px; text-align:right;">${amount}</td>
         </tr>
       `;
-    })
-    .join("\n");
+      })
+      .join("\n") +
+    (items.length
+      ? `
+      <tr>
+        <td style="padding:4px"></td>
+        <td style="padding:4px"></td>
+        <td colspan="3" style="padding:4px; text-align:center;">
+          <span style="font-size:12px; color:#333;">*****Nothing Follows*****</span>
+        </td>
+        <td style="padding:4px"></td>
+        <td style="padding:4px"></td>
+        <td style="padding:4px"></td>
+      </tr>
+    `
+      : "");
 
-  const totalAmount = items.reduce(
-    (sum, it) => sum + Number(it?.amount ?? it?.PurchaseOrderItem?.amount ?? 0),
-    0
-  );
+  const totalAmount = items.reduce((sum, it) => sum + Number(it?.amount ?? it?.PurchaseOrderItem?.amount ?? 0), 0);
   const formattedTotal = items[0]?.formatAmount ?? totalAmount ?? "";
 
   const overallComplete = items.length && items.every((i) => i.iarStatus === "complete");
   const overallPartial = items.some((i) => i.iarStatus === "partial");
 
-
-  console.log("Overall Complete:", reportData,overallComplete);
+  console.log("Overall Complete:", reportData, overallComplete);
 
   return `
     <html lang="en">
@@ -331,7 +334,11 @@ export const getInspectionReportTemplateForIAR = (
             <tr class="total-row">
               <td></td>
               <td></td>
-              <td colspan="4"></td>
+              <td colspan="4" style="padding-left:6px;">
+                  <p style="font-size:12px;">Income: <span>(Value)</span></p>
+                  <p style="font-size:12px;">MDS: <span>(Value)</span></p>
+                  <p style="font-size:12px;">Details: <span>(Value)</span></p>
+              </td>
               <td>Total</td>
              <td>${escapeHtml(String(formattedTotal))}</td>
             </tr>
@@ -357,15 +364,15 @@ export const getInspectionReportTemplateForIAR = (
                   <div>Date Received: _____</div>
                   <div style="display:flex; flex-direction:column; gap:6px;">
                       <div style="display:flex; align-items:center; gap:8px;">
-                        <div style="width:40px; aspect-ratio:3/2; border:1px dotted black; background:${overallComplete ? '#ccc' : 'transparent'}; display:flex; align-items:center; justify-content:center; font-size:16px; font-weight:bold;">
-                          ${overallComplete ? '✓' : ''}
+                        <div style="width:40px; aspect-ratio:3/2; border:1px dotted black; background:${overallComplete ? "#ccc" : "transparent"}; display:flex; align-items:center; justify-content:center; font-size:16px; font-weight:bold;">
+                          ${overallComplete ? "✓" : ""}
                         </div>
                         <p style="margin:0; width:65px;">Complete</p>
                       </div>
 
                       <div style="display:flex; align-items:center; gap:8px;">
-                        <div style="width:40px; aspect-ratio:3/2; border:1px dotted black; background:${overallPartial ? '#ccc' : 'transparent'}; display:flex; align-items:center; justify-content:center; font-size:16px; font-weight:bold;">
-                          ${overallPartial ? '✓' : ''}
+                        <div style="width:40px; aspect-ratio:3/2; border:1px dotted black; background:${overallPartial ? "#ccc" : "transparent"}; display:flex; align-items:center; justify-content:center; font-size:16px; font-weight:bold;">
+                          ${overallPartial ? "✓" : ""}
                         </div>
                         <p style="margin:0; width:65px;">Partial</p>
                       </div>


### PR DESCRIPTION
Inserted a 'Nothing Follows' row after item listings in both preview and print Inspection & Acceptance Report for IAR components. Added Income, MDS, and Details fields to the total row for improved clarity. Also refactored code for conciseness and readability.