### PR TITLE
Add 'Nothing Follows' and financial info rows to slips

### DIFF
--- a/app/src/components/previewDocumentFiles/inventoryCustodianSlip.tsx
+++ b/app/src/components/previewDocumentFiles/inventoryCustodianSlip.tsx
@@ -1,16 +1,5 @@
-import React, { useRef, useEffect } from 'react';
-import {
-  Box,
-  Typography,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-  styled
-} from "@mui/material";
+import React, { useRef, useEffect } from "react";
+import { Box, Typography, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, styled } from "@mui/material";
 import { genericPreviewProps } from "../../types/previewPrintDocument/types";
 import { Divider } from "@mui/material";
 import { escapeHtml, nl2br } from "../../utils/textHelpers";
@@ -19,13 +8,13 @@ const StyledTableCell = styled(TableCell)(({ theme }) => ({
   border: "1px solid black",
   padding: "4px",
   fontSize: "12px",
-  fontWeight: "normal"
+  fontWeight: "normal",
 }));
 
 const StyledTableCellHeader = styled(StyledTableCell)(({ theme }) => ({
   whiteSpace: "nowrap",
   textAlign: "left",
-  padding: "0px 6px"
+  padding: "0px 6px",
 }));
 
 const StyledTableRow = styled(TableRow)({
@@ -35,46 +24,40 @@ const StyledTableRow = styled(TableRow)({
 });
 
 const HeaderTableCell = styled(StyledTableCell)({
-  padding: 0
+  padding: 0,
 });
 
 // Improved PrintContainer with better print isolation
 const PrintContainer = styled(Box)({
-  '@media print': {
-    position: 'fixed',
+  "@media print": {
+    position: "fixed",
     left: 0,
     top: 0,
-    width: '210mm',
-    height: '297mm',
+    width: "210mm",
+    height: "297mm",
     margin: 0,
     padding: 0,
-    pageBreakAfter: 'always',
-    backgroundColor: 'white',
+    pageBreakAfter: "always",
+    backgroundColor: "white",
     zIndex: 9999,
-    visibility: 'visible'
-  }
+    visibility: "visible",
+  },
 });
 
 // Controls for buttons that shouldn't print
 const PrintControls = styled(Box)({
-  '@media print': {
-    display: 'none !important'
-  }
+  "@media print": {
+    display: "none !important",
+  },
 });
 
-
-export default function InventoryCustodianSlip({
-  signatories,
-  reportData,
-  onPrint,
-  onClose,
-}: genericPreviewProps) {
+export default function InventoryCustodianSlip({ signatories, reportData, onPrint, onClose }: genericPreviewProps) {
   const componentRef = useRef(null);
   // const { inspectionOfficer , supplyOfficer, receivedFrom } = signatories
   // Create and inject print styles dynamically
   useEffect(() => {
     // Create a style element
-    const style = document.createElement('style');
+    const style = document.createElement("style");
     style.innerHTML = `
       @media print {
         @page {
@@ -104,10 +87,10 @@ export default function InventoryCustodianSlip({
         }
       }
     `;
-    
+
     // Append the style to the document head
     document.head.appendChild(style);
-    
+
     // Clean up on component unmount
     return () => {
       document.head.removeChild(style);
@@ -115,33 +98,31 @@ export default function InventoryCustodianSlip({
   }, []);
 
   // Check if reportData is an array, if not, convert it to an array for consistent handling
-  const itemsArray = Array.isArray(reportData) 
-    ? reportData.filter(item => item !== null && item !== undefined) 
-    : (reportData ? [reportData] : []);
-  
+  const itemsArray = Array.isArray(reportData) ? reportData.filter((item) => item !== null && item !== undefined) : reportData ? [reportData] : [];
+
   // Calculate total amount from all items
   const totalAmount = itemsArray.reduce((sum, item) => {
     return sum + (item?.amount || 0);
   }, 0);
-  
+
   // Format the total amount
   const formatTotalAmount = `₱${totalAmount.toFixed(2)}`;
 
   // Build a display string of unique ICS IDs
   const icsIdsDisplay = React.useMemo(() => {
     const ids = Array.from(new Set(itemsArray.map((it: any) => it?.icsId).filter(Boolean)));
-    return ids.join(', ');
+    return ids.join(", ");
   }, [itemsArray]);
 
   return (
     <>
-      <PrintControls sx={{ mb: 2, display: 'flex', justifyContent: 'space-between' }}>
+      <PrintControls sx={{ mb: 2, display: "flex", justifyContent: "space-between" }}>
         {/* <Button onClick={onClose} variant="outlined">Back</Button> */}
         {/* <Button onClick={handlePrint} variant="contained">Print Report</Button>  */}
       </PrintControls>
-      
+
       <Box id="printable-report" ref={componentRef}>
-        <TableContainer component={Paper} elevation={0} sx={{ border: '1px solid black' }}>
+        <TableContainer component={Paper} elevation={0} sx={{ border: "1px solid black" }}>
           <Table sx={{ width: "100%", borderCollapse: "collapse" }}>
             <TableHead>
               <TableRow sx={{ visibility: "collapse", height: 0 }}>
@@ -162,7 +143,7 @@ export default function InventoryCustodianSlip({
                       flexDirection: "column",
                       padding: "4px 0px",
                       position: "relative",
-                      gap: "0.5em"
+                      gap: "0.5em",
                     }}
                   >
                     <Box
@@ -171,7 +152,7 @@ export default function InventoryCustodianSlip({
                         display: "grid",
                         gridTemplateColumns: "1fr 1.75fr 1fr",
                         alignItems: "center",
-                        textAlign: "center"
+                        textAlign: "center",
                       }}
                     >
                       <Box sx={{ display: "grid", placeItems: "center" }}>
@@ -182,7 +163,7 @@ export default function InventoryCustodianSlip({
                           sx={{
                             width: "90px",
                             aspectRatio: "1/1",
-                            objectFit: "contain"
+                            objectFit: "contain",
                           }}
                         />
                       </Box>
@@ -192,18 +173,12 @@ export default function InventoryCustodianSlip({
                           placeItems: "center",
                           alignContent: "center",
                           textAlign: "center",
-                          padding: "1rem 0px 3rem 0px"
+                          padding: "1rem 0px 3rem 0px",
                         }}
                       >
-                        <Typography sx={{ fontSize: "14px", fontWeight: "normal", textTransform: "uppercase" }}>
-                          Republic of the Philippines
-                        </Typography>
-                        <Typography sx={{ fontSize: "16px", fontWeight: "bold", textTransform: "uppercase" }}>
-                          Carlos Hilado Memorial State University
-                        </Typography>
-                        <Typography sx={{ fontSize: "16px", fontWeight: "900", textTransform: "uppercase" }}>
-                          Inventory Custodian Slip
-                        </Typography>
+                        <Typography sx={{ fontSize: "14px", fontWeight: "normal", textTransform: "uppercase" }}>Republic of the Philippines</Typography>
+                        <Typography sx={{ fontSize: "16px", fontWeight: "bold", textTransform: "uppercase" }}>Carlos Hilado Memorial State University</Typography>
+                        <Typography sx={{ fontSize: "16px", fontWeight: "900", textTransform: "uppercase" }}>Inventory Custodian Slip</Typography>
                       </Box>
                       <Box
                         sx={{
@@ -211,7 +186,7 @@ export default function InventoryCustodianSlip({
                           display: "flex",
                           flexDirection: "column",
                           justifyContent: "space-between",
-                          alignItems: "flex-end"
+                          alignItems: "flex-end",
                         }}
                       >
                         <Box sx={{ display: "flex", flexDirection: "column" }}>
@@ -220,7 +195,7 @@ export default function InventoryCustodianSlip({
                               fontFamily: "serif",
                               fontStyle: "italic",
                               fontWeight: "bold",
-                              fontSize: "14px"
+                              fontSize: "14px",
                             }}
                           >
                             Appendix 59
@@ -228,7 +203,7 @@ export default function InventoryCustodianSlip({
                           <Typography
                             sx={{
                               textAlign: "center",
-                              fontSize: "12px"
+                              fontSize: "12px",
                             }}
                           >
                             page 1/1
@@ -240,7 +215,7 @@ export default function InventoryCustodianSlip({
                             display: "grid",
                             gridTemplateColumns: "auto 1fr",
                             gap: "0.5ch",
-                            marginLeft: "calc(3rem * -1)"
+                            marginLeft: "calc(3rem * -1)",
                           }}
                         >
                           <Typography sx={{ fontWeight: "bold", fontSize: "12px" }}>ICS No: </Typography>
@@ -248,7 +223,7 @@ export default function InventoryCustodianSlip({
                         </Box>
                       </Box>
                     </Box>
-                    
+
                     <Box
                       sx={{
                         display: "flex",
@@ -256,23 +231,25 @@ export default function InventoryCustodianSlip({
                         justifyContent: "flex-end",
                         alignItems: "flex-start",
                         padding: "0px",
-                        marginTop: "0.5rem"
+                        marginTop: "0.5rem",
                       }}
                     >
-                      <Typography sx={{ fontSize: "14px" }}>
-                        Entity Name: Carlos Hilado Memorial State University
-                      </Typography>
+                      <Typography sx={{ fontSize: "14px" }}>Entity Name: Carlos Hilado Memorial State University</Typography>
                       <Typography sx={{ fontSize: "14px" }}>Date: {itemsArray[0]?.PurchaseOrder?.dateOfDelivery || ""}</Typography>
                     </Box>
                   </Box>
                 </HeaderTableCell>
               </TableRow>
-              
+
               <TableRow>
                 <StyledTableCell rowSpan={2}>Quantity</StyledTableCell>
                 <StyledTableCell rowSpan={2}>Unit</StyledTableCell>
-                <StyledTableCell colSpan={2} align="center">Amount</StyledTableCell>
-                <StyledTableCell rowSpan={2} colSpan={2}>Description</StyledTableCell>
+                <StyledTableCell colSpan={2} align="center">
+                  Amount
+                </StyledTableCell>
+                <StyledTableCell rowSpan={2} colSpan={2}>
+                  Description
+                </StyledTableCell>
                 {/* <StyledTableCell>Inventory</StyledTableCell> */}
                 <StyledTableCell colSpan={2}>Estimated</StyledTableCell>
               </TableRow>
@@ -286,88 +263,111 @@ export default function InventoryCustodianSlip({
 
             <TableBody>
               {itemsArray && itemsArray.length > 0 ? (
-                itemsArray.map((item, index) => (
-                  <StyledTableRow key={item?.id || index}>
-                    <StyledTableCell align="center">{item?.actualQuantityReceived || ''}</StyledTableCell>
-                    <StyledTableCell colSpan={2} align="center">{item?.unit || ''}</StyledTableCell>
-                    {/* <StyledTableCell align="right">
+                <>
+                  {itemsArray.map((item, index) => (
+                    <StyledTableRow key={item?.id || index}>
+                      <StyledTableCell align="center">{item?.actualQuantityReceived || ""}</StyledTableCell>
+                      <StyledTableCell colSpan={2} align="center">
+                        {item?.unit || ""}
+                      </StyledTableCell>
+                      {/* <StyledTableCell align="right">
                       {item?.formatUnitCost || (item?.unitCost ? `₱${item.unitCost.toFixed(2)}` : '')}
                     </StyledTableCell> */}
-                    <StyledTableCell align="right">
-                      {item?.formatAmount || (item?.amount ? `₱${item.amount.toFixed(2)}` : '')}
-                    </StyledTableCell>
-                    <StyledTableCell colSpan={2} align="left">
-                      <Box>
-                        <Typography sx={{ fontWeight: 500 }}>
-                          {item?.description || item?.PurchaseOrderItem?.description || ""}
-                        </Typography>
+                      <StyledTableCell align="right">{item?.formatAmount || (item?.amount ? `₱${item.amount.toFixed(2)}` : "")}</StyledTableCell>
+                      <StyledTableCell colSpan={2} align="left">
+                        <Box>
+                          <Typography sx={{ fontWeight: 500 }}>{item?.description || item?.PurchaseOrderItem?.description || ""}</Typography>
 
-                        {/* specification (escaped + newline -> <br/>) */}
-                        {(item?.PurchaseOrderItem?.specification || item?.specification) && (
-                          <Typography
-                            component="div"
-                            sx={{ fontSize: 12, color: "text.secondary", mt: 0.5, textAlign: "left" }}
-                            dangerouslySetInnerHTML={{
-                              __html: nl2br(
-                                escapeHtml(item?.PurchaseOrderItem?.specification || item?.specification || "")
-                              ),
-                            }}
-                          />
-                        )}
+                          {/* specification (escaped + newline -> <br/>) */}
+                          {(item?.PurchaseOrderItem?.specification || item?.specification) && (
+                            <Typography
+                              component="div"
+                              sx={{ fontSize: 12, color: "text.secondary", mt: 0.5, textAlign: "left" }}
+                              dangerouslySetInnerHTML={{
+                                __html: nl2br(escapeHtml(item?.PurchaseOrderItem?.specification || item?.specification || "")),
+                              }}
+                            />
+                          )}
 
-                        {/* general description (escaped + newline -> <br/>) */}
-                        {(item?.PurchaseOrderItem?.generalDescription || item?.generalDescription) && (
-                          <Typography
-                            component="div"
-                            sx={{ fontSize: 12, color: "text.secondary", mt: 0.5, textAlign: "left" }}
-                            dangerouslySetInnerHTML={{
-                              __html: nl2br(
-                                escapeHtml(item?.PurchaseOrderItem?.generalDescription || item?.generalDescription || "")
-                              ),
-                            }}
-                          />
-                        )}
-                      </Box>
+                          {/* general description (escaped + newline -> <br/>) */}
+                          {(item?.PurchaseOrderItem?.generalDescription || item?.generalDescription) && (
+                            <Typography
+                              component="div"
+                              sx={{ fontSize: 12, color: "text.secondary", mt: 0.5, textAlign: "left" }}
+                              dangerouslySetInnerHTML={{
+                                __html: nl2br(escapeHtml(item?.PurchaseOrderItem?.generalDescription || item?.generalDescription || "")),
+                              }}
+                            />
+                          )}
+                        </Box>
+                      </StyledTableCell>
+                      {/* <StyledTableCell align="center">{item.inventoryNumber|| ''}</StyledTableCell> */}
+                      <StyledTableCell colSpan={2} align="center">
+                        5 years
+                      </StyledTableCell>
+                    </StyledTableRow>
+                  ))}
+                  <StyledTableRow>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell colSpan={2}></StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell colSpan={2} sx={{ textAlign: "center", padding: 0.5 }}>
+                      <Typography sx={{ fontSize: "12px", color: "text.secondary" }}>*****Nothing Follows*****</Typography>
                     </StyledTableCell>
-                    {/* <StyledTableCell align="center">{item.inventoryNumber|| ''}</StyledTableCell> */}
-                    <StyledTableCell colSpan={2} align="center">5 years</StyledTableCell>
+                    <StyledTableCell colSpan={2}></StyledTableCell>
                   </StyledTableRow>
-                ))
+
+                  <StyledTableRow>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell colSpan={2}></StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell colSpan={2} sx={{ textAlign: "left", padding: 0.5 }}>
+                      <Typography fontSize={12}>
+                        Income: <span>(Value)</span>
+                      </Typography>
+                      <Typography fontSize={12}>
+                        MDS: <span>(Value)</span>
+                      </Typography>
+                      <Typography fontSize={12}>
+                        Details: <span>(Value)</span>
+                      </Typography>
+                    </StyledTableCell>
+                    <StyledTableCell colSpan={2}></StyledTableCell>
+                  </StyledTableRow>
+                </>
               ) : (
                 <StyledTableRow>
                   <StyledTableCell></StyledTableCell>
-                  <StyledTableCell></StyledTableCell>
-                  <StyledTableCell></StyledTableCell>
-                  <StyledTableCell></StyledTableCell>
                   <StyledTableCell colSpan={2}></StyledTableCell>
                   <StyledTableCell></StyledTableCell>
-                  <StyledTableCell></StyledTableCell>
+                  <StyledTableCell colSpan={2}></StyledTableCell>
+                  <StyledTableCell colSpan={2}></StyledTableCell>
                 </StyledTableRow>
               )}
-              
+
               <StyledTableRow>
-                {/* <StyledTableCell colSpan={3} align="right" sx={{ fontWeight: 600 }}>Total</StyledTableCell> */}
+                {/* <StyledTableCell colSpan={3} align="right" sx={{ fontWeight: 600 }}>
+                  Total
+                </StyledTableCell> */}
                 {/* <StyledTableCell align="right">{formatTotalAmount}</StyledTableCell> */}
-                <StyledTableCell colSpan={7}></StyledTableCell>
+                <StyledTableCell colSpan={8} sx={{ height: "27px" }}></StyledTableCell>
               </StyledTableRow>
-            
+
               {/* Move this TableRow inside TableBody */}
               <TableRow>
                 <StyledTableCell colSpan={8}>
-                  <Typography sx={{ fontWeight: "lighter", fontSize: "12px" }}>
-                    I hereby acknowledge receipt of the following property/ies issued for my use and for which I am responsible:
-                  </Typography>
+                  <Typography sx={{ fontWeight: "lighter", fontSize: "12px" }}>I hereby acknowledge receipt of the following property/ies issued for my use and for which I am responsible:</Typography>
                 </StyledTableCell>
               </TableRow>
-              
+
               {/* Move this TableRow inside TableBody */}
               <TableRow>
-                <StyledTableCell colSpan={4} sx={{ padding: "20px 0px" }}>
+                <StyledTableCell colSpan={5} sx={{ padding: "20px 0px" }}>
                   <Box
                     sx={{
                       display: "flex",
                       flexDirection: "column",
-                      padding: "2px"
+                      padding: "2px",
                     }}
                   >
                     <Box sx={{ fontWeight: 600 }}>Received from:</Box>
@@ -382,14 +382,14 @@ export default function InventoryCustodianSlip({
                         alignContent: "stretch",
                         alignItems: "stretch",
                         justifyContent: "flex-end",
-                        textAlign: "center"
+                        textAlign: "center",
                       }}
                     >
-                        <span>{signatories?.recieved_from}</span> 
-                     <Divider sx={{ width: "100%", margin: "5px 0" }} />
+                      <span>{signatories?.recieved_from}</span>
+                      <Divider sx={{ width: "100%", margin: "5px 0" }} />
                       <Typography sx={{ fontWeight: 600 }}></Typography>
                       {/* <Typography sx={{ fontWeight: 600 }}>{itemsArray[0]?.PurchaseOrder?.supplier || ""}</Typography> */}
-                     <Divider sx={{ width: "100%", margin: "5px 0" }} />
+                      <Divider sx={{ width: "100%", margin: "5px 0" }} />
                     </Box>
                     <Box
                       sx={{
@@ -397,7 +397,7 @@ export default function InventoryCustodianSlip({
                         margin: "0 auto",
                         display: "flex",
                         flexDirection: "column",
-                        gap: "3px"
+                        gap: "3px",
                       }}
                     >
                       <Typography>Signature over Printed Name</Typography>
@@ -406,12 +406,12 @@ export default function InventoryCustodianSlip({
                     </Box>
                   </Box>
                 </StyledTableCell>
-                <StyledTableCell colSpan={4} sx={{ padding: "20px 0px" }}>
+                <StyledTableCell colSpan={3} sx={{ padding: "20px 0px" }}>
                   <Box
                     sx={{
                       display: "flex",
                       flexDirection: "column",
-                      padding: "2px"
+                      padding: "2px",
                     }}
                   >
                     <Box sx={{ fontWeight: 600 }}>Received by:</Box>
@@ -426,13 +426,13 @@ export default function InventoryCustodianSlip({
                         alignContent: "stretch",
                         alignItems: "stretch",
                         justifyContent: "flex-end",
-                        textAlign: "center"
+                        textAlign: "center",
                       }}
                     >
-                       <span>{signatories?.recieved_by}</span>
-                     <Divider sx={{ width: "100%", margin: "5px 0" }} />
+                      <span>{signatories?.recieved_by}</span>
+                      <Divider sx={{ width: "100%", margin: "5px 0" }} />
                       <Typography sx={{ fontWeight: 600 }}>Custodian</Typography>
-                     <Divider sx={{ width: "100%", margin: "5px 0" }} />
+                      <Divider sx={{ width: "100%", margin: "5px 0" }} />
                     </Box>
                     <Box
                       sx={{
@@ -440,7 +440,7 @@ export default function InventoryCustodianSlip({
                         margin: "0 auto",
                         display: "flex",
                         flexDirection: "column",
-                        gap: "3px"
+                        gap: "3px",
                       }}
                     >
                       <Typography>Signature over Printed Name</Typography>
@@ -451,7 +451,7 @@ export default function InventoryCustodianSlip({
                 </StyledTableCell>
               </TableRow>
             </TableBody>
-            
+
             {/* Create a TableFooter for the note */}
             <tfoot>
               <TableRow>

--- a/app/src/components/previewDocumentFiles/requisitionAndIssueSlip.tsx
+++ b/app/src/components/previewDocumentFiles/requisitionAndIssueSlip.tsx
@@ -1,18 +1,5 @@
 import React, { useRef, useEffect } from "react";
-import {
-  Box,
-  Typography,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-  styled,
-  Button,
-  Divider,
-} from "@mui/material";
+import { Box, Typography, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, styled, Button, Divider } from "@mui/material";
 import { genericPreviewProps } from "../../types/previewPrintDocument/types";
 import useSignatoryStore from "../../stores/signatoryStore";
 import { capitalizeFirstLetter } from "../../utils/generalUtils";
@@ -65,17 +52,10 @@ const PrintControls = styled(Box)({
   },
 });
 
-export default function RequisitionReport({
-  signatories,
-  reportData,
-  onPrint,
-  onClose,
-}: genericPreviewProps) {
+export default function RequisitionReport({ signatories, reportData, onPrint, onClose }: genericPreviewProps) {
   const componentRef = useRef(null);
 
   console.log("signatories", signatories);
-
- 
 
   // Create and inject print styles dynamically
   useEffect(() => {
@@ -121,11 +101,7 @@ export default function RequisitionReport({
   }, []);
 
   // Check if reportData is an array, if not, convert it to an array for consistent handling
-  const itemsArray = Array.isArray(reportData)
-    ? reportData.filter((item) => item !== null && item !== undefined)
-    : reportData
-      ? [reportData]
-      : [];
+  const itemsArray = Array.isArray(reportData) ? reportData.filter((item) => item !== null && item !== undefined) : reportData ? [reportData] : [];
 
   // Calculate total amount from all items
   const totalAmount = itemsArray.reduce((sum, item) => {
@@ -137,27 +113,19 @@ export default function RequisitionReport({
 
   // Build a display string of unique RIS IDs from the report data
   const risIdsDisplay = React.useMemo(() => {
-    const ids = Array.from(
-      new Set(itemsArray.map((it: any) => it?.risId).filter(Boolean))
-    );
-    return ids.join(', ');
+    const ids = Array.from(new Set(itemsArray.map((it: any) => it?.risId).filter(Boolean)));
+    return ids.join(", ");
   }, [itemsArray]);
 
   return (
     <>
-      <PrintControls
-        sx={{ mb: 2, display: "flex", justifyContent: "space-between" }}
-      >
+      <PrintControls sx={{ mb: 2, display: "flex", justifyContent: "space-between" }}>
         {/* <Button onClick={onClose} variant="outlined">Back</Button> */}
         {/* <Button onClick={handlePrint} variant="contained">Print Report</Button>  */}
       </PrintControls>
 
       <Box id="printable-report" ref={componentRef}>
-        <TableContainer
-          component={Paper}
-          elevation={0}
-          sx={{ border: "1px solid black" }}
-        >
+        <TableContainer component={Paper} elevation={0} sx={{ border: "1px solid black" }}>
           <Table sx={{ width: "100%", borderCollapse: "collapse" }}>
             <TableHead>
               <TableRow sx={{ visibility: "collapse", height: 0 }}>
@@ -213,22 +181,13 @@ export default function RequisitionReport({
                           placeItems: "center",
                         }}
                       >
-                        <Typography
-                          variant="h6"
-                          sx={{ fontSize: "14px", fontWeight: "normal" }}
-                        >
+                        <Typography variant="h6" sx={{ fontSize: "14px", fontWeight: "normal" }}>
                           REPUBLIC OF THE PHILIPPINES
                         </Typography>
-                        <Typography
-                          variant="h5"
-                          sx={{ fontSize: "16px", fontWeight: 600 }}
-                        >
+                        <Typography variant="h5" sx={{ fontSize: "16px", fontWeight: 600 }}>
                           CARLOS HILADO MEMORIAL STATE UNIVERSITY
                         </Typography>
-                        <Typography
-                          variant="h6"
-                          sx={{ fontSize: "14px", fontWeight: "normal" }}
-                        >
+                        <Typography variant="h6" sx={{ fontSize: "14px", fontWeight: "normal" }}>
                           REQUISITION AND ISSUE SLIP
                         </Typography>
                       </Box>
@@ -292,9 +251,7 @@ export default function RequisitionReport({
                       }}
                     >
                       <Typography>Division:</Typography>
-                      <Box
-                        sx={{ borderBottom: "1px solid #000", width: "100%" }}
-                      ></Box>
+                      <Box sx={{ borderBottom: "1px solid #000", width: "100%" }}></Box>
                     </Box>
                     <Box
                       sx={{
@@ -305,13 +262,7 @@ export default function RequisitionReport({
                     >
                       <Typography>Office: </Typography>
 
-                      <Box
-                        sx={{ borderBottom: "1px solid #000", width: "100%" }}
-                      >
-                        {" "}
-                        &nbsp; &nbsp;{" "}
-                        {itemsArray[0]?.PurchaseOrder?.placeOfDelivery || ""}
-                      </Box>
+                      <Box sx={{ borderBottom: "1px solid #000", width: "100%" }}> &nbsp; &nbsp; {itemsArray[0]?.PurchaseOrder?.placeOfDelivery || ""}</Box>
                     </Box>
                   </Box>
                 </StyledTableCellHeader>
@@ -326,9 +277,7 @@ export default function RequisitionReport({
                       }}
                     >
                       <Typography>Responsibility Center Code : </Typography>
-                      <Box
-                        sx={{ borderBottom: "1px solid #000", width: "100%" }}
-                      ></Box>
+                      <Box sx={{ borderBottom: "1px solid #000", width: "100%" }}></Box>
                     </Box>
                     <Box
                       sx={{
@@ -338,11 +287,7 @@ export default function RequisitionReport({
                       }}
                     >
                       <Typography>RIS No. :</Typography>
-                      <Box
-                        sx={{ borderBottom: "1px solid #000", width: "100%" }}
-                      >
-                        {" "}&nbsp; &nbsp;{risIdsDisplay}
-                      </Box>
+                      <Box sx={{ borderBottom: "1px solid #000", width: "100%" }}> &nbsp; &nbsp;{risIdsDisplay}</Box>
                     </Box>
                   </Box>
                 </HeaderTableCell>
@@ -400,49 +345,80 @@ export default function RequisitionReport({
 
             <TableBody>
               {itemsArray?.length > 0 ? (
-                itemsArray.map((item: any, index: any) => (
-                  <StyledTableRow key={index}>
-                    <StyledTableCell>{" "}</StyledTableCell>
-                    <StyledTableCell>{index + 1 || ""}</StyledTableCell>
-                    <StyledTableCell>{item.unit || ""}</StyledTableCell>
-                    <StyledTableCell colSpan={2}>
-                      <Box>
-                        <Typography sx={{ fontWeight: 500 }}>
-                          {item.description || item.PurchaseOrderItem?.description || ""}
-                        </Typography>
+                <>
+                  {itemsArray.map((item: any, index: any) => (
+                    <StyledTableRow key={index}>
+                      <StyledTableCell> </StyledTableCell>
+                      <StyledTableCell>{index + 1 || ""}</StyledTableCell>
+                      <StyledTableCell>{item.unit || ""}</StyledTableCell>
+                      <StyledTableCell colSpan={2}>
+                        <Box>
+                          <Typography sx={{ fontWeight: 500 }}>{item.description || item.PurchaseOrderItem?.description || ""}</Typography>
 
-                        {(item.PurchaseOrderItem?.specification || item.specification) && (
-                          <Typography
-                            component="div"
-                            sx={{ fontSize: 12, color: "text.secondary", mt: 0.5, textAlign: "left" }}
-                            dangerouslySetInnerHTML={{
-                              __html: nl2br(
-                                escapeHtml(item.PurchaseOrderItem?.specification || item.specification || "")
-                              ),
-                            }}
-                          />
-                        )}
+                          {(item.PurchaseOrderItem?.specification || item.specification) && (
+                            <Typography
+                              component="div"
+                              sx={{ fontSize: 12, color: "text.secondary", mt: 0.5, textAlign: "left" }}
+                              dangerouslySetInnerHTML={{
+                                __html: nl2br(escapeHtml(item.PurchaseOrderItem?.specification || item.specification || "")),
+                              }}
+                            />
+                          )}
 
-                        {(item.PurchaseOrderItem?.generalDescription || item.generalDescription) && (
-                          <Typography
-                            component="div"
-                            sx={{ fontSize: 12, color: "text.secondary", mt: 0.5, textAlign: "left" }}
-                            dangerouslySetInnerHTML={{
-                              __html: nl2br(
-                                escapeHtml(item.PurchaseOrderItem?.generalDescription || item.generalDescription || "")
-                              ),
-                            }}
-                          />
-                        )}
-                      </Box>
+                          {(item.PurchaseOrderItem?.generalDescription || item.generalDescription) && (
+                            <Typography
+                              component="div"
+                              sx={{ fontSize: 12, color: "text.secondary", mt: 0.5, textAlign: "left" }}
+                              dangerouslySetInnerHTML={{
+                                __html: nl2br(escapeHtml(item.PurchaseOrderItem?.generalDescription || item.generalDescription || "")),
+                              }}
+                            />
+                          )}
+                        </Box>
+                      </StyledTableCell>
+                      <StyledTableCell>{item.actualQuantityReceived || ""}</StyledTableCell>
+                      <StyledTableCell colSpan={2}></StyledTableCell>
+                      <StyledTableCell></StyledTableCell>
+                      <StyledTableCell> </StyledTableCell>
+                      <StyledTableCell></StyledTableCell>
+                    </StyledTableRow>
+                  ))}
+
+                  <StyledTableRow>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell colSpan={2} sx={{ textAlign: "center", padding: 0.5 }}>
+                      <Typography sx={{ fontSize: "12px", color: "text.secondary" }}>*****Nothing Follows*****</Typography>
                     </StyledTableCell>
-                    <StyledTableCell>{item.actualQuantityReceived || ""}</StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
                     <StyledTableCell colSpan={2}></StyledTableCell>
                     <StyledTableCell></StyledTableCell>
-                    <StyledTableCell>{" "}</StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
                     <StyledTableCell></StyledTableCell>
                   </StyledTableRow>
-                ))
+                  <StyledTableRow>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell colSpan={2} sx={{ textAlign: "left", padding: 0.5 }}>
+                      <Typography fontSize={12}>
+                        Income: <span>(Value)</span>
+                      </Typography>
+                      <Typography fontSize={12}>
+                        MDS: <span>(Value)</span>
+                      </Typography>
+                      <Typography fontSize={12}>
+                        Details: <span>(Value)</span>
+                      </Typography>
+                    </StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell colSpan={2}></StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
+                    <StyledTableCell></StyledTableCell>
+                  </StyledTableRow>
+                </>
               ) : (
                 <StyledTableRow>
                   <StyledTableCell></StyledTableCell>
@@ -465,10 +441,8 @@ export default function RequisitionReport({
                 <StyledTableCell></StyledTableCell>
                 <StyledTableCell colSpan={2}></StyledTableCell>
                 <StyledTableCell></StyledTableCell>
-                <StyledTableCell align="right"> {" "} </StyledTableCell>
-                <StyledTableCell align="right">
-                  {/* {formatTotalAmount} */ " "}
-                </StyledTableCell>
+                <StyledTableCell align="right"> </StyledTableCell>
+                <StyledTableCell align="right">{/* {formatTotalAmount} */ " "}</StyledTableCell>
               </StyledTableRow>
             </TableBody>
 
@@ -502,24 +476,16 @@ export default function RequisitionReport({
               <StyledTableRow>
                 <StyledTableCell colSpan={2}>Printed Name :</StyledTableCell>
                 <StyledTableCell>
-                  <Typography>
-                    {capitalizeFirstLetter(signatories?.requested_by || "")}
-                  </Typography>
+                  <Typography>{capitalizeFirstLetter(signatories?.requested_by || "")}</Typography>
                 </StyledTableCell>
                 <StyledTableCell colSpan={2}>
-                  <Typography>
-                    {capitalizeFirstLetter(signatories?.approved_by || "")}
-                  </Typography>
+                  <Typography>{capitalizeFirstLetter(signatories?.approved_by || "")}</Typography>
                 </StyledTableCell>
                 <StyledTableCell colSpan={3}>
-                  <Typography>
-                    {capitalizeFirstLetter(signatories?.issued_by || "")}
-                  </Typography>
+                  <Typography>{capitalizeFirstLetter(signatories?.issued_by || "")}</Typography>
                 </StyledTableCell>
                 <StyledTableCell colSpan={3}>
-                  <Typography>
-                    {capitalizeFirstLetter(signatories?.recieved_by || "")}
-                  </Typography>
+                  <Typography>{capitalizeFirstLetter(signatories?.recieved_by || "")}</Typography>
                 </StyledTableCell>
               </StyledTableRow>
 

--- a/app/src/components/printDocumentFiles/inventoryCustodianslipPrinting.tsx
+++ b/app/src/components/printDocumentFiles/inventoryCustodianslipPrinting.tsx
@@ -27,7 +27,7 @@ export const getInventoryTemplateForICS = (signatories: any, reportData: any) =>
       const unitCostDisplay = item?.formatUnitCost || (item?.unitCost ? `₱${item.unitCost.toFixed(2)}` : "");
       const amountDisplay = item?.formatAmount || (item?.amount ? `₱${item.amount.toFixed(2)}` : "");
 
-    let row = `
+      let row = `
         <tr>
           <td>${escapeHtml(item?.actualQuantityReceived || "")}</td>
           <td colspan="2">${escapeHtml(item?.unit || "")}</td>
@@ -43,21 +43,33 @@ export const getInventoryTemplateForICS = (signatories: any, reportData: any) =>
           <td></td>
           <td colspan="2"></td>
           <td></td>
-          <td colspan="2" style="text-align: center;">********Nothing Follows********</td>
+          <td colspan="2" style="text-align: center;"><br/>********Nothing Follows********</td>
+          <td  colspan="2"></td>
+        </tr>
+        <tr>
+          <td></td>
+          <td colspan="2"></td>
+          <td></td>
+          <td colspan="2" style="text-align: left;">
+            <br/>
+            <span style="font-size:12px; color:#333;">
+              <p style="font-size:12px;">Income: <span>(Value)</span></p>
+              <p style="font-size:12px;">MDS: <span>(Value)</span></p>
+              <p style="font-size:12px;">Details: <span>(Value)</span></p>
+            </span>
+          </td>
           <td  colspan="2"></td>
         </tr>
         `;
-        // row += `
-        //   <tr>
-        //     <td style="height: 100%"></td>
-        //     <td>&nbsp;</td>
-        //     <td>&nbsp;</td>
-        //     <td>&nbsp;</td>
-        //     <td colspan="2">&nbsp;</td>
-        //     <td>&nbsp;</td>
-        //     <td>&nbsp;</td>
-        //   </tr>
-        // `;
+        row += `
+          <tr>
+            <td style="height: 100%"></td>
+            <td colspan="2">&nbsp;</td>
+            <td>&nbsp;</td>
+            <td colspan="2">&nbsp;</td>
+            <td colspan="2">&nbsp;</td>
+          </tr>
+        `;
       }
       return row;
     })
@@ -370,12 +382,10 @@ tfoot {
             <tfoot>
          <tr>
           <td></td>
-          <td></td>
-          <td></td>
-          <td></td>
           <td colspan="2"></td>
           <td></td>
-          <td></td>
+          <td colspan="2"></td>
+          <td colspan="2"></td>
         </tr>
                 <tr>
                     <td colspan="8">
@@ -385,7 +395,7 @@ tfoot {
                     </td>
                 </tr>
                 <tr>
-                    <td colspan="4" style="padding: 20px 0px;">
+                    <td colspan="5" style="padding: 20px 0px;">
                         <div style="display: flex; flex-direction: column; padding: 2px;">
                             <div style="font-weight: 600;">Received from:</div>
                             <div style="display: flex; flex-direction: column; padding: 22px 75px; gap: 20px; height: 125px; margin-top: 5px; align-content: stretch; align-items: stretch; justify-content: flex-end; text-align: center;">
@@ -401,7 +411,7 @@ tfoot {
                             </div>
                         </div>
                     </td>
-                    <td colspan="4" style="padding: 20px 0px;">
+                    <td colspan="3" style="padding: 20px 0px;">
                         <div style="display: flex; flex-direction: column; padding: 2px;">
                             <div style="font-weight: 600;">Received by:</div>
                             <div style="display: flex; flex-direction: column; padding: 22px 75px; gap: 20px; height: 125px; margin-top: 5px; align-content: stretch; align-items: stretch; justify-content: flex-end; text-align: center;">

--- a/app/src/components/printDocumentFiles/requisitionAndIssueSlip.tsx
+++ b/app/src/components/printDocumentFiles/requisitionAndIssueSlip.tsx
@@ -38,7 +38,7 @@ export const getRequisitionAndIssueSlip = (signatories: any, reportData: any) =>
                     <td>${escapeHtml(String(item?.actualQuantityReceived ?? ""))}</td>
                     <td colspan="2"></td>
                     <td></td>
-                    <td>${escapeHtml(String( " "))}</td>
+                    <td>${escapeHtml(String(" "))}</td>
                     <td></td>
                 </tr>
       `;
@@ -48,7 +48,25 @@ export const getRequisitionAndIssueSlip = (signatories: any, reportData: any) =>
           <td></td>
           <td></td>
           <td></td>
-          <td colspan="2" style="text-align: center;">********Nothing Follows********</td>
+          <td colspan="2" style="text-align: center;"><br/>********Nothing Follows********</td>
+          <td></td>
+          <td colspan="2"></td>
+          <td></td>
+          <td></td>
+          <td></td>
+        </tr>
+        <tr>
+          <td></td>
+          <td></td>
+          <td></td>
+          <td colspan="2" style="text-align: left;">
+            <br/>
+            <span style="font-size:12px; color:#333;">
+              <p style="font-size:12px;">Income: <span>(Value)</span></p>
+              <p style="font-size:12px;">MDS: <span>(Value)</span></p>
+              <p style="font-size:12px;">Details: <span>(Value)</span></p>
+            </span>
+          </td>
           <td></td>
           <td colspan="2"></td>
           <td></td>


### PR DESCRIPTION
Enhanced both Inventory Custodian Slip and Requisition and Issue Slip preview and print templates to include '*****Nothing Follows*****' and additional rows for Income, MDS, and Details. Also adjusted table cell spans and alignment for consistency between preview and print versions.