### PR TITLE
tester

### DIFF
--- a/api/resolvers/purchaseorder.resolver.js
+++ b/api/resolvers/purchaseorder.resolver.js
@@ -8,9 +8,9 @@ import { sequelize } from "../db/connectDB.js";
 import { Op } from "sequelize"; // add if not present
 const nanoid = customAlphabet("1234567890meguizomarkoliver", 10);
 import { generateNewIarId } from "../utils/iarIdGenerator.js";
-import { generateNewRisId } from "../utils/risIdGenerator.js";
-import { generateNewParId } from "../utils/parIdGenerator.js";
-import { generateNewIcsId } from "../utils/icsIdGenerator.js";
+import { generateNewRisId, resetRisIdBatch } from "../utils/risIdGenerator.js";
+import { generateNewParId, resetParIdBatch } from "../utils/parIdGenerator.js";
+import { generateNewIcsId, resetIcsIdBatch } from "../utils/icsIdGenerator.js";
 const purchaseorderResolver = {
   Query: {
     purchaseOrders: async (_, __, context) => {
@@ -283,8 +283,13 @@ const purchaseorderResolver = {
 
         // If items exist, create purchase order items
         if (items && Array.isArray(items) && items.length > 0) {
-          // Use a single ICS ID for the entire batch, regardless of tag (high/low)
-          let batchIcsId = "";
+          // COMMENTED OUT FOR DEMO: Use a single ICS ID for the entire batch, regardless of tag (high/low)
+          // let batchIcsId = "";
+          
+          // Reset batch tracking for individual ID generation
+          resetIcsIdBatch();
+          resetParIdBatch();
+          resetRisIdBatch();
           // Validate that if items are provided, at least one item has meaningful data
           const hasAtLeastOneValidItem = items.some((item) => {
             const itemNameIsValid =
@@ -334,10 +339,15 @@ const purchaseorderResolver = {
               };
               const campusSuffix = campusSuffixMap[campus] || '';
               if (cleanedItems.tag === "high" || cleanedItems.tag === "low") {
-                if (!batchIcsId) {
-                  batchIcsId = await generateNewIcsId(cleanedItems.tag);
-                }
-                icsId = campusSuffix ? `${batchIcsId}${campusSuffix}` : batchIcsId;
+                // COMMENTED OUT FOR DEMO: Batch ICS ID logic
+                // if (!batchIcsId) {
+                //   batchIcsId = await generateNewIcsId(cleanedItems.tag);
+                // }
+                // icsId = campusSuffix ? `${batchIcsId}${campusSuffix}` : batchIcsId;
+                
+                // Generate individual ICS ID for each item
+                const gen = await generateNewIcsId(cleanedItems.tag);
+                icsId = campusSuffix ? `${gen}${campusSuffix}` : gen;
               }
               if (
                 cleanedItems.category === "property acknowledgement reciept"
@@ -478,8 +488,13 @@ const purchaseorderResolver = {
         // Handle items if provided
         if (items && Array.isArray(items) && items.length > 0) {
           // Use a single ICS ID for the entire update batch, regardless of tag
-          let batchIcsId = "";
+          // let batchIcsId = "";
           // Generate a single IAR ID for all items in this batch
+          
+          // Reset ID batch tracking for this transaction
+          resetIcsIdBatch();
+          resetParIdBatch();
+          resetRisIdBatch();
 
           const hasAtLeastOneValidItem = items.some((item) => {
             const itemNameIsValid =
@@ -575,10 +590,13 @@ const purchaseorderResolver = {
                   risIdGen = campusSuffix ? `${gen}${campusSuffix}` : gen;
                 }
                 if (effectiveTag === "high" || effectiveTag === "low") {
-                  if (!batchIcsId) {
-                    batchIcsId = await generateNewIcsId(effectiveTag);
-                  }
-                  icsIdGen = campusSuffix ? `${batchIcsId}${campusSuffix}` : batchIcsId;
+                  // if (!batchIcsId) {
+                  //   batchIcsId = await generateNewIcsId(effectiveTag);
+                  // }
+                  // icsIdGen = campusSuffix ? `${batchIcsId}${campusSuffix}` : batchIcsId;
+                  // Generate individual ICS ID for each item
+                  const individualIcsId = await generateNewIcsId(effectiveTag);
+                  icsIdGen = campusSuffix ? `${individualIcsId}${campusSuffix}` : individualIcsId;
                 }
 
                 // Apply updates + increment actualQuantityReceived
@@ -696,10 +714,13 @@ const purchaseorderResolver = {
                 const campusSuffix = campusSuffixMap[campusValue] || "";
 
                 if (cleanedItems.tag === "high" || cleanedItems.tag === "low") {
-                  if (!batchIcsId) {
-                    batchIcsId = await generateNewIcsId(cleanedItems.tag);
-                  }
-                  icsId = campusSuffix ? `${batchIcsId}${campusSuffix}` : batchIcsId;
+                  // if (!batchIcsId) {
+                  //   batchIcsId = await generateNewIcsId(cleanedItems.tag);
+                  // }
+                  // icsId = campusSuffix ? `${batchIcsId}${campusSuffix}` : batchIcsId;
+                  // Generate individual ICS ID for each item
+                  const individualIcsId = await generateNewIcsId(cleanedItems.tag);
+                  icsId = campusSuffix ? `${individualIcsId}${campusSuffix}` : individualIcsId;
                 }
                 if (item.category === "property acknowledgement reciept") {
                   const gen = await generateNewParId();

--- a/api/utils/parIdGenerator.js
+++ b/api/utils/parIdGenerator.js
@@ -1,10 +1,26 @@
 import inspectionAcceptanceReport from "../models/inspectionacceptancereport.js";
-import { Op } from "sequelize";
+import { Op, Sequelize } from "sequelize";
+
+// Track the last generated PAR ID within the same batch/request to avoid duplicates
+let lastGeneratedParSequence = 0;
+let lastGeneratedParYear = null;
+
+// Call this at the start of each new request/transaction to reset batch tracking
+export function resetParIdBatch() {
+  lastGeneratedParSequence = 0;
+  lastGeneratedParYear = null;
+}
 
 export async function generateNewParId() {
   const year = new Date().getFullYear();
   const yearPrefix = year.toString().slice(-2) + "-";
   console.log(yearPrefix);
+
+  // Reset tracking if year changed
+  if (lastGeneratedParYear !== year) {
+    lastGeneratedParSequence = 0;
+    lastGeneratedParYear = year;
+  }
 
   const lastestPar = await inspectionAcceptanceReport.findOne({
     where: {
@@ -12,7 +28,9 @@ export async function generateNewParId() {
         [Op.like]: `${yearPrefix}%`,
       },
     },
-    order: [["createdAt", "DESC"]],
+    order: [
+      [Sequelize.literal("CAST(REPLACE(SUBSTRING_INDEX(parId, '-', -1), SUBSTRING(SUBSTRING_INDEX(parId, '-', -1), -1), '') AS UNSIGNED)"), 'DESC'],
+    ],
     attributes: ["parId"],
   });
 
@@ -21,11 +39,23 @@ export async function generateNewParId() {
     const parts = lastestPar.parId.split("-");
 
     if (parts.length === 2) {
-      const lastSequence = parseInt(parts[1], 10);
-      nextSeriesNumber = lastSequence + 1;
+      // Remove any suffix like 'B', 'T', 'A', 'F' etc.
+      const numericPart = parts[1].replace(/[A-Za-z]/g, '');
+      const lastSequence = parseInt(numericPart, 10);
+      if (!isNaN(lastSequence)) {
+        nextSeriesNumber = lastSequence + 1;
+      }
     }
   }
 
+  // Also check against the last generated sequence in this batch to avoid duplicates
+  if (lastGeneratedParSequence >= nextSeriesNumber) {
+    nextSeriesNumber = lastGeneratedParSequence + 1;
+  }
+
+  // Track this generated sequence
+  lastGeneratedParSequence = nextSeriesNumber;
+
   const formattedSeriesNumber = nextSeriesNumber.toString().padStart(3, "0");
-    return `${yearPrefix}${formattedSeriesNumber}`;
+  return `${yearPrefix}${formattedSeriesNumber}`;
 }

--- a/api/utils/risIdGenerator.js
+++ b/api/utils/risIdGenerator.js
@@ -1,5 +1,15 @@
 import inspectionAcceptanceReport from '../models/inspectionacceptancereport.js';
-import { Op } from 'sequelize';
+import { Op, Sequelize } from 'sequelize';
+
+// Track the last generated RIS ID within the same batch/request to avoid duplicates
+let lastGeneratedRisSequence = 0;
+let lastGeneratedRisYear = null;
+
+// Call this at the start of each new request/transaction to reset batch tracking
+export function resetRisIdBatch() {
+  lastGeneratedRisSequence = 0;
+  lastGeneratedRisYear = null;
+}
 
 /**
  * Generates a new Requisition and Issue Slip (RIS) ID in the format YYYY-MM-NNNN.
@@ -15,6 +25,12 @@ export async function generateNewRisId() {
 
   const yearPrefix = `${year}-`;
 
+  // Reset tracking if year changed
+  if (lastGeneratedRisYear !== year) {
+    lastGeneratedRisSequence = 0;
+    lastGeneratedRisYear = year;
+  }
+
   // Find the latest RIS entry for the current year to determine the next sequence number.
   const latestRis = await inspectionAcceptanceReport.findOne({
     where: {
@@ -22,7 +38,9 @@ export async function generateNewRisId() {
         [Op.like]: `${yearPrefix}%`,
       },
     },
-    order: [['createdAt', 'DESC']], // Assuming updatedAt reflects the order of ID generation.
+    order: [
+      [Sequelize.literal("CAST(REPLACE(SUBSTRING_INDEX(risId, '-', -1), SUBSTRING(SUBSTRING_INDEX(risId, '-', -1), -1), '') AS UNSIGNED)"), 'DESC'],
+    ],
     attributes: ['risId'],
   });
 
@@ -30,12 +48,22 @@ export async function generateNewRisId() {
   if (latestRis && latestRis.risId) {
     const parts = latestRis.risId.split('-');
     if (parts.length === 3) {
-      const lastSequence = parseInt(parts[2], 10);
+      // Remove any suffix like 'B', 'T', 'A', 'F' etc.
+      const numericPart = parts[2].replace(/[A-Za-z]/g, '');
+      const lastSequence = parseInt(numericPart, 10);
       if (!isNaN(lastSequence)) {
         newSequence = lastSequence + 1;
       }
     }
   }
+
+  // Also check against the last generated sequence in this batch to avoid duplicates
+  if (lastGeneratedRisSequence >= newSequence) {
+    newSequence = lastGeneratedRisSequence + 1;
+  }
+
+  // Track this generated sequence
+  lastGeneratedRisSequence = newSequence;
 
   const sequenceStr = newSequence.toString().padStart(4, '0');
   return `${year}-${month}-${sequenceStr}`;


### PR DESCRIPTION
This pull request implements robust in-memory batch tracking for ICS, PAR, and RIS ID generation to prevent duplicate IDs within the same request or transaction, and ensures correct sequence incrementation even when multiple items are processed together. It also updates the ID generation logic to handle suffixes and resets the batch tracking at the start of relevant operations.

**Batch ID generation improvements:**

* Introduced in-memory tracking and reset functions (`resetIcsIdBatch`, `resetParIdBatch`, `resetRisIdBatch`) for ICS, PAR, and RIS IDs to avoid duplicate IDs during batch operations and ensure correct sequencing within the same request. These reset functions are now called at the start of relevant create/update operations in `purchaseorder.resolver.js`. [[1]](diffhunk://#diff-cd27294ce204977de0eaa02acdf2113ec5cd61a1b1e9b787589c1b8d169b2338L11-R13) [[2]](diffhunk://#diff-cd27294ce204977de0eaa02acdf2113ec5cd61a1b1e9b787589c1b8d169b2338L286-R292) [[3]](diffhunk://#diff-cd27294ce204977de0eaa02acdf2113ec5cd61a1b1e9b787589c1b8d169b2338L481-R498) [[4]](diffhunk://#diff-bc13a47d7d772b1b4f0f4fad2db0b2b2cebc3d903356b5acf275660130a1fd60L4-R14) [[5]](diffhunk://#diff-daeee3aa2a4c03fcfc42607dd32c7e080c8129b6d12ec5efcf37bad360536f14L2-R33) [[6]](diffhunk://#diff-53ad41c33c5bc1a40d4fdc3b718dc956d0a4fd7a9aa4cabe36fb19df0e0a8244L2-R12)

* Modified the ID generation functions (`generateNewIcsId`, `generateNewParId`, `generateNewRisId`) to check and update the last generated sequence for the current batch, and reset the sequence if the year changes. This ensures unique and sequential IDs even if multiple are generated in the same transaction. [[1]](diffhunk://#diff-bc13a47d7d772b1b4f0f4fad2db0b2b2cebc3d903356b5acf275660130a1fd60R40-R46) [[2]](diffhunk://#diff-bc13a47d7d772b1b4f0f4fad2db0b2b2cebc3d903356b5acf275660130a1fd60L49-R96) [[3]](diffhunk://#diff-daeee3aa2a4c03fcfc42607dd32c7e080c8129b6d12ec5efcf37bad360536f14L24-R57) [[4]](diffhunk://#diff-53ad41c33c5bc1a40d4fdc3b718dc956d0a4fd7a9aa4cabe36fb19df0e0a8244R28-R67)

**ICS ID assignment logic changes:**

* Changed the logic for ICS ID assignment in `purchaseorder.resolver.js` so that each item now receives an individually generated ICS ID, rather than sharing a single batch ICS ID. The previous batch logic is commented out for reference. [[1]](diffhunk://#diff-cd27294ce204977de0eaa02acdf2113ec5cd61a1b1e9b787589c1b8d169b2338L337-R350) [[2]](diffhunk://#diff-cd27294ce204977de0eaa02acdf2113ec5cd61a1b1e9b787589c1b8d169b2338L578-R599) [[3]](diffhunk://#diff-cd27294ce204977de0eaa02acdf2113ec5cd61a1b1e9b787589c1b8d169b2338L699-R723)

**ID parsing and sequencing robustness:**

* Updated the SQL ordering and parsing logic in all ID generators to correctly extract and increment the numeric part of IDs, even when suffixes (like 'B', 'T', etc.) are present, ensuring proper sequencing. [[1]](diffhunk://#diff-bc13a47d7d772b1b4f0f4fad2db0b2b2cebc3d903356b5acf275660130a1fd60L49-R96) [[2]](diffhunk://#diff-daeee3aa2a4c03fcfc42607dd32c7e080c8129b6d12ec5efcf37bad360536f14L24-R57) [[3]](diffhunk://#diff-53ad41c33c5bc1a40d4fdc3b718dc956d0a4fd7a9aa4cabe36fb19df0e0a8244R28-R67)